### PR TITLE
feature: expand/collapse toggle for long sidebar comments

### DIFF
--- a/extension/src/popup/side-panel.js
+++ b/extension/src/popup/side-panel.js
@@ -665,9 +665,30 @@ async function loadComments(videoId) {
             ${likesText}
           </div>
           <p class="comment-text">${sanitizeCommentHtml(c.text)}</p>
+          <button class="comment-expand-btn" data-expanded="false">Show more</button>
         </div>
       `;
     }).join('');
+
+    // Hide expand buttons for comments that aren't actually clamped
+    list.querySelectorAll('.comment-card').forEach(card => {
+      const textEl = card.querySelector('.comment-text');
+      const btn = card.querySelector('.comment-expand-btn');
+      if (textEl.scrollHeight <= textEl.clientHeight) {
+        btn.style.display = 'none';
+      }
+    });
+
+    // Toggle expand / collapse
+    list.addEventListener('click', e => {
+      const btn = e.target.closest('.comment-expand-btn');
+      if (!btn) return;
+      const textEl = btn.closest('.comment-card').querySelector('.comment-text');
+      const isExpanded = btn.dataset.expanded === 'true';
+      textEl.classList.toggle('expanded', !isExpanded);
+      btn.dataset.expanded = String(!isExpanded);
+      btn.textContent = isExpanded ? 'Show more' : 'Show less';
+    });
   } catch (error) {
     list.innerHTML = `<div class="no-bookmarks">${error.message}</div>`;
   }

--- a/extension/styles/side-panel.css
+++ b/extension/styles/side-panel.css
@@ -1386,10 +1386,33 @@ body {
   color: var(--text-sub);
   line-height: 1.5;
   margin: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
+  max-height: 72px; /* 4 lines × 12px × 1.5 */
   overflow: hidden;
+  transition: max-height 0.35s ease;
+}
+
+.comment-text.expanded {
+  max-height: 800px;
+  transition: max-height 0.45s ease;
+}
+
+.comment-expand-btn {
+  background: none;
+  border: none;
+  padding: 4px 0 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent, #14B8A6);
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  text-align: left;
+  opacity: 0.85;
+}
+
+.comment-expand-btn:hover {
+  opacity: 1;
+  text-decoration: underline;
 }
 
 .comment-skeleton {


### PR DESCRIPTION
## What
Added a **Show more / Show less** toggle to comment cards in the sidebar comments panel.

## Why
Long comments were being hard-clamped to 4 lines with no way to read the full text, making the comments section difficult to use.

## Changes
- Replaced `-webkit-line-clamp` with `max-height: 72px` (equivalent 4-line cap) to enable CSS transitions
- Added `.comment-text.expanded` with `max-height: 800px` and a smooth `ease` transition (0.35s collapse / 0.45s expand)
- Injected a "Show more" button per comment card; auto-hidden when content already fits within the collapsed height
- Single event-delegated click listener on the list toggles expanded state and flips button label to "Show less"

## Testing
- Manually verified toggle expands and collapses with smooth animation
- Button correctly hidden on short comments that don't overflow 4 lines