### PR TITLE
Sync all bookmarks from cloud on extension dashboard load

### DIFF
--- a/extension/src/popup/dashboard.js
+++ b/extension/src/popup/dashboard.js
@@ -1755,44 +1755,49 @@ async function syncAllWithCloud() {
   const token = await getValidToken();
   if (!token) return 0;
 
+  // Fetch all bookmarks from cloud in a single request
+  const cloudRes = await fetch(`${API_BASE}/api/bookmarks`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!cloudRes.ok) return 0;
+  const { videos: cloudVideos } = await cloudRes.json();
+
   const allData = await new Promise(resolve => chrome.storage.sync.get(null, resolve));
-  const videoIds = Object.keys(allData)
+  const cloudVideoIds = new Set((cloudVideos || []).map(v => v.videoId));
+  const localVideoIds = Object.keys(allData)
     .filter(k => k.startsWith('bm_') && Array.isArray(allData[k]))
     .map(k => k.slice(3));
 
-  if (!videoIds.length) return 0;
-
   let updatedCount = 0;
-  for (const videoId of videoIds) {
+
+  // Merge cloud → local for every video in cloud (handles new-device case where local is empty)
+  for (const { videoId, bookmarks: cloudBms } of (cloudVideos || [])) {
     try {
       const localBms = allData[bmKey(videoId)] || [];
-      if (!localBms.length) continue;
-
-      const res = await fetch(`${API_BASE}/api/bookmarks?videoId=${encodeURIComponent(videoId)}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) continue;
-      const { bookmarks: cloudBms } = await res.json();
-
-      const cloudIds = new Set((cloudBms || []).map(b => b.id));
       const localIds = new Set(localBms.map(b => b.id));
       const newFromCloud = (cloudBms || []).filter(b => !localIds.has(b.id));
-      const newFromLocal = localBms.filter(b => !cloudIds.has(b.id));
-
-      if (!newFromCloud.length && !newFromLocal.length) continue;
+      if (!newFromCloud.length) continue;
 
       const merged = [...localBms, ...newFromCloud];
-      if (newFromCloud.length) {
-        await new Promise(resolve => chrome.storage.sync.set({ [bmKey(videoId)]: merged }, resolve));
-      }
-      await fetch(`${API_BASE}/api/bookmarks`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ videoId, bookmarks: merged }),
-      });
+      await new Promise(resolve => chrome.storage.sync.set({ [bmKey(videoId)]: merged }, resolve));
       updatedCount++;
     } catch { /* skip this video */ }
   }
+
+  // Push any local-only videos to cloud
+  for (const videoId of localVideoIds) {
+    if (cloudVideoIds.has(videoId)) continue;
+    const localBms = allData[bmKey(videoId)] || [];
+    if (!localBms.length) continue;
+    try {
+      await fetch(`${API_BASE}/api/bookmarks`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ videoId, bookmarks: localBms }),
+      });
+    } catch { /* skip this video */ }
+  }
+
   return updatedCount;
 }
 
@@ -1856,7 +1861,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   updateViewToggle();
   updateDensityBtn();
+  // Silently pull all cloud bookmarks on open so cross-device data is available immediately
   loadAllBookmarks();
+  syncAllWithCloud().then(updated => {
+    if (updated > 0) loadAllBookmarks();
+  }).catch(() => {});
   renderSavedFilterPills();
   updateRevisitBadge();
 

--- a/webapp/app/api/bookmarks/route.ts
+++ b/webapp/app/api/bookmarks/route.ts
@@ -45,18 +45,36 @@ async function getAuthenticatedUser(request: NextRequest) {
   return { user, client: serverClient };
 }
 
-// GET /api/bookmarks?videoId=xxx
+// GET /api/bookmarks?videoId=xxx  — single video
+// GET /api/bookmarks               — all videos (for full cross-device sync)
 export async function GET(request: NextRequest) {
   const videoId = request.nextUrl.searchParams.get('videoId');
-  if (!videoId) {
-    return NextResponse.json({ error: 'videoId is required' }, { status: 400 });
-  }
 
   const auth = await getAuthenticatedUser(request);
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   if (!await isProUser(auth.user.id)) {
     return NextResponse.json({ error: 'pro_required' }, { status: 403 });
+  }
+
+  if (!videoId) {
+    // Return all bookmarks for the user (used by extension dashboard on load)
+    const { data, error } = await auth.client
+      .from('user_bookmarks')
+      .select('video_id, bookmarks, updated_at')
+      .eq('user_id', auth.user.id);
+
+    if (error) {
+      return NextResponse.json({ error: 'Failed to fetch bookmarks' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      videos: (data ?? []).map(row => ({
+        videoId: row.video_id,
+        bookmarks: row.bookmarks,
+        updatedAt: row.updated_at,
+      })),
+    });
   }
 
   const { data, error } = await auth.client


### PR DESCRIPTION
The extension dashboard only synced videos already in local storage, so device-exclusive bookmarks never appeared cross-device even though the cloud had them all.

Changes:
- GET /api/bookmarks (no videoId) now returns all user bookmark rows
- syncAllWithCloud() fetches all cloud videos first, then merges any missing into chrome.storage.sync (instead of per-local-video)
- Dashboard auto-runs sync on open; re-renders if new bookmarks arrive