### PR TITLE
refactor: centralize hardcoded constants across extension and webapp

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,6 +21,8 @@
     {
       "resources": [
         "src/pages/dashboard.html",
+        "src/constants.js",
+        "src/config.js",
         "src/popup/dashboard.js",
         "styles/dashboard.css"
       ],
@@ -43,7 +45,7 @@
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "js": ["src/content/content.js"],
+      "js": ["src/constants.js", "src/content/content.js"],
       "run_at": "document_end",
       "css": []
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,8 +21,6 @@
     {
       "resources": [
         "src/pages/dashboard.html",
-        "src/constants.js",
-        "src/config.js",
         "src/popup/dashboard.js",
         "styles/dashboard.css"
       ],

--- a/extension/src/constants.js
+++ b/extension/src/constants.js
@@ -1,0 +1,47 @@
+// ─── Tag colours (single source of truth for all extension files) ──────────
+// Must stay in sync with webapp/app/dashboard/_utils/tagColors.ts
+const TAG_COLORS = {
+  important: '#ef4444',
+  review:    '#f97316',
+  note:      '#3b82f6',
+  question:  '#22c55e',
+  todo:      '#a855f7',
+  key:       '#ec4899',
+};
+
+function parseTags(description) {
+  if (!description) return [];
+  const matches = description.match(/#(\w+)/g);
+  return matches ? matches.map(t => t.slice(1).toLowerCase()) : [];
+}
+
+function stringToColor(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  return `hsl(${Math.abs(hash) % 360}, 55%, 45%)`;
+}
+
+function getTagColor(tags) {
+  if (!tags || tags.length === 0) return '#4da1ee';
+  return TAG_COLORS[tags[0]] || stringToColor(tags[0]);
+}
+
+// ─── YouTube URL helpers ────────────────────────────────────────────────────
+function ytWatchUrl(videoId, t = 0) {
+  return `https://www.youtube.com/watch?v=${videoId}${t ? `&t=${Math.floor(t)}s` : ''}`;
+}
+
+function ytThumbnailUrl(videoId, quality = 'mqdefault') {
+  return `https://img.youtube.com/vi/${videoId}/${quality}.jpg`;
+}
+
+// ─── App constants ──────────────────────────────────────────────────────────
+const APP_EXPORT_PREFIX = 'clipmark';
+
+// ─── Retry / timing ────────────────────────────────────────────────────────
+const MAX_RECONNECT_ATTEMPTS = 3;
+const RECONNECT_DELAY        = 1000; // ms
+
+// ─── String limits ──────────────────────────────────────────────────────────
+const TITLE_TRUNCATE_LENGTH      = 60;
+const TRANSCRIPT_TRUNCATE_LENGTH = 120;

--- a/extension/src/content/content.js
+++ b/extension/src/content/content.js
@@ -10,8 +10,7 @@ let video = null;
 let progressBar = null;
 let isInitialized = false;
 let reconnectAttempts = 0;
-const MAX_RECONNECT_ATTEMPTS = 3;
-const RECONNECT_DELAY = 1000;
+// MAX_RECONNECT_ATTEMPTS and RECONNECT_DELAY are defined in constants.js
 
 // ─── Revisit mode state ───────────────────────────────────────────────────────
 let revisionState = null; // { segments, index, countdownTimer, speed }
@@ -27,34 +26,7 @@ let cachedTranscript       = null; // null = not fetched yet, [] = fetched but e
 let transcriptFetchPromise = null;
 let cachedTranscriptVideoId = null;
 
-// ─── Tag colours (must match popup.js) ───────────────────────────────────────
-const TAG_COLORS = {
-  important: '#ef4444',
-  review:    '#f97316',
-  note:      '#3b82f6',
-  question:  '#22c55e',
-  todo:      '#a855f7',
-  key:       '#ec4899',
-};
-
-function parseTags(description) {
-  if (!description) return [];
-  const matches = description.match(/#(\w+)/g);
-  return matches ? matches.map(t => t.slice(1).toLowerCase()) : [];
-}
-
-function stringToColor(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return `hsl(${Math.abs(hash) % 360}, 55%, 45%)`;
-}
-
-function getTagColor(tags) {
-  if (!tags || tags.length === 0) return '#4da1ee';
-  return TAG_COLORS[tags[0]] || stringToColor(tags[0]);
-}
+// TAG_COLORS, parseTags, stringToColor, getTagColor are defined in constants.js
 
 function bmKey(videoId) { return `bm_${videoId}`; }
 
@@ -435,8 +407,8 @@ function cleanTranscriptText(text) {
   // Capitalize first letter
   t = t.charAt(0).toUpperCase() + t.slice(1);
   // Truncate at word boundary to ~120 chars
-  if (t.length > 120) {
-    t = t.substring(0, 120).replace(/\s+\S*$/, '') + '…';
+  if (t.length > TRANSCRIPT_TRUNCATE_LENGTH) {
+    t = t.substring(0, TRANSCRIPT_TRUNCATE_LENGTH).replace(/\s+\S*$/, '') + '…';
   }
   return t || null;
 }

--- a/extension/src/pages/dashboard.html
+++ b/extension/src/pages/dashboard.html
@@ -203,6 +203,7 @@
     <div id="error-toast"   class="error-toast"></div>
     <div id="success-toast" class="success-toast"></div>
 
+    <script src="../constants.js"></script>
     <script src="../config.js"></script>
     <script src="../popup/dashboard.js"></script>
 </body>

--- a/extension/src/pages/popup.html
+++ b/extension/src/pages/popup.html
@@ -205,6 +205,7 @@
   </div>
 
 </div><!-- /.popup-root -->
+<script src="../constants.js"></script>
 <script src="../config.js"></script>
 <script src="../ai/local-ai.js"></script>
 <script src="../popup/popup.js"></script>

--- a/extension/src/pages/side-panel.html
+++ b/extension/src/pages/side-panel.html
@@ -223,6 +223,7 @@
 
 </div><!-- /.side-panel-container -->
 
+<script src="../constants.js"></script>
 <script src="../config.js"></script>
 <script src="../ai/local-ai.js"></script>
 <script src="../popup/side-panel.js"></script>

--- a/extension/src/popup/dashboard.js
+++ b/extension/src/popup/dashboard.js
@@ -28,28 +28,7 @@ async function getValidToken() {
   }
 }
 
-// ─── Tag colours (must match popup.js / content.js) ──────────────────────────
-const TAG_COLORS = {
-  important: '#ef4444',
-  review:    '#f97316',
-  note:      '#3b82f6',
-  question:  '#22c55e',
-  todo:      '#a855f7',
-  key:       '#ec4899',
-};
-
-function stringToColor(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return `hsl(${Math.abs(hash) % 360}, 55%, 45%)`;
-}
-
-function getTagColor(tags) {
-  if (!tags || tags.length === 0) return '#4da1ee';
-  return TAG_COLORS[tags[0]] || stringToColor(tags[0]);
-}
+// TAG_COLORS, stringToColor, getTagColor are defined in constants.js
 
 function bmKey(videoId) { return `bm_${videoId}`; }
 
@@ -394,8 +373,8 @@ async function renderBookmarks() {
       .sort((a, b) => (b.createdAt ? new Date(b.createdAt).getTime() : b.id) - (a.createdAt ? new Date(a.createdAt).getTime() : a.id))
       .map(b => b.videoTitle)
       .find(t => t) || videoTitles[videoId] || `Video: ${videoId}`;
-    const ytUrl  = `https://www.youtube.com/watch?v=${videoId}`;
-    const thumb  = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
+    const ytUrl  = ytWatchUrl(videoId);
+    const thumb  = ytThumbnailUrl(videoId);
     const count  = bookmarks.length;
 
     const card = document.createElement('div');
@@ -662,7 +641,7 @@ function renderTimelineView(bookmarks, container) {
     items.forEach(b => {
       const side     = idx % 2 === 0 ? 'tl-left' : 'tl-right';
       const color    = b.color || getTagColor(b.tags);
-      const thumb    = `https://img.youtube.com/vi/${b.videoId}/mqdefault.jpg`;
+      const thumb    = ytThumbnailUrl(b.videoId);
       const tagsHtml = b.tags?.length
         ? `<div class="tl-tags">${b.tags.map(t =>
             `<span class="tag-badge" style="background:${getTagColor([t])}18;color:${getTagColor([t])}">#${t}</span>`
@@ -740,7 +719,7 @@ function attachEventListeners() {
         .sort((a, b) => a.timestamp - b.timestamp);
       if (!bookmarks.length) return;
       await chrome.storage.local.set({ pendingRevision: { videoId, bookmarks } });
-      chrome.tabs.create({ url: `https://www.youtube.com/watch?v=${videoId}` });
+      chrome.tabs.create({ url: ytWatchUrl(videoId) });
     });
   });
 
@@ -754,7 +733,7 @@ function attachEventListeners() {
     btn.addEventListener('click', async e => {
       e.stopPropagation();
       const { videoId, timestamp } = e.currentTarget.dataset;
-      const url = `https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(parseFloat(timestamp))}`;
+      const url = ytWatchUrl(videoId, parseFloat(timestamp));
       await navigator.clipboard.writeText(url);
       showToast('Link copied!', 'success');
     });
@@ -900,7 +879,7 @@ function attachEventListeners() {
 }
 
 function jumpToVideo(videoId, timestamp) {
-  window.open(`https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(timestamp)}`, '_blank');
+  window.open(ytWatchUrl(videoId, timestamp), '_blank');
 }
 
 // ─── Export ───────────────────────────────────────────────────────────────────
@@ -915,7 +894,7 @@ function downloadFile(content, filename, mimeType) {
 }
 
 function exportJSON() {
-  downloadFile(JSON.stringify(allBookmarks, null, 2), 'clipmark-bookmarks.json', 'application/json');
+  downloadFile(JSON.stringify(allBookmarks, null, 2), `${APP_EXPORT_PREFIX}-bookmarks.json`, 'application/json');
 }
 
 function exportCSV() {
@@ -928,7 +907,7 @@ function exportCSV() {
      b.createdAt]
     .map(v => `"${v}"`).join(',')
   ).join('\n');
-  downloadFile(header + rows, 'clipmark-bookmarks.csv', 'text/csv');
+  downloadFile(header + rows, `${APP_EXPORT_PREFIX}-bookmarks.csv`, 'text/csv');
 }
 
 function exportMarkdown() {
@@ -940,17 +919,17 @@ function exportMarkdown() {
 
   for (const [videoId, bookmarks] of Object.entries(groups)) {
     const title = videoTitles[videoId] || videoId;
-    lines.push(`## [${title}](https://www.youtube.com/watch?v=${videoId})\n`);
+    lines.push(`## [${title}](${ytWatchUrl(videoId)})\n`);
     bookmarks.sort((a, b) => a.timestamp - b.timestamp).forEach(b => {
       const tagStr = b.tags && b.tags.length ? ` ${b.tags.map(t => `#${t}`).join(' ')}` : '';
-      const url    = `https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(b.timestamp)}`;
+      const url    = ytWatchUrl(videoId, b.timestamp);
       lines.push(`- [${formatTimestamp(b.timestamp)}](${url}) — ${b.description || 'No description'}${tagStr}`);
       if (b.notes && b.notes.trim()) lines.push(`  > ${b.notes.replace(/\n/g, '\n  > ')}`);
     });
     lines.push('');
   }
 
-  downloadFile(lines.join('\n'), 'clipmark-bookmarks.md', 'text/markdown');
+  downloadFile(lines.join('\n'), `${APP_EXPORT_PREFIX}-bookmarks.md`, 'text/markdown');
 }
 
 async function exportObsidian() {
@@ -962,10 +941,10 @@ async function exportObsidian() {
 
   for (const [videoId, bookmarks] of Object.entries(groups)) {
     const title = bookmarks[0].videoTitle || videoId;
-    const ytUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    const ytUrl = ytWatchUrl(videoId);
     lines.push(`> [!note] [${title}](${ytUrl})\n`);
     bookmarks.sort((a, b) => a.timestamp - b.timestamp).forEach(b => {
-      const url    = `${ytUrl}&t=${Math.floor(b.timestamp)}`;
+      const url    = ytWatchUrl(videoId, b.timestamp);
       const tagStr = b.tags?.length ? ` ${b.tags.map(t => `#${t}`).join(' ')}` : '';
       lines.push(`> - [${formatTimestamp(b.timestamp)}](${url}) — ${b.description || 'No note'}${tagStr}`);
       if (b.notes?.trim()) lines.push(`>   > ${b.notes.replace(/\n/g, '\n>   > ')}`);
@@ -973,7 +952,7 @@ async function exportObsidian() {
     lines.push('');
   }
 
-  downloadFile(lines.join('\n'), 'clipmark-obsidian.md', 'text/markdown');
+  downloadFile(lines.join('\n'), `${APP_EXPORT_PREFIX}-obsidian.md`, 'text/markdown');
 }
 
 async function exportNotionCSV() {
@@ -982,7 +961,7 @@ async function exportNotionCSV() {
 
   const header = 'Name,Video,URL,Tags,Notes,Date\n';
   const rows   = allBookmarks.map(b => {
-    const url = `https://www.youtube.com/watch?v=${b.videoId}&t=${Math.floor(b.timestamp)}`;
+    const url = ytWatchUrl(b.videoId, b.timestamp);
     return [
       `${formatTimestamp(b.timestamp)} — ${(b.description || '').replace(/"/g, '""')}`,
       (b.videoTitle || '').replace(/"/g, '""'),
@@ -993,7 +972,7 @@ async function exportNotionCSV() {
     ].map(v => `"${v}"`).join(',');
   }).join('\n');
 
-  downloadFile(header + rows, 'clipmark-notion.csv', 'text/csv');
+  downloadFile(header + rows, `${APP_EXPORT_PREFIX}-notion.csv`, 'text/csv');
 }
 
 async function exportReadingList() {
@@ -1005,7 +984,7 @@ async function exportReadingList() {
 
   for (const [videoId, bookmarks] of Object.entries(groups)) {
     const title = bookmarks[0].videoTitle || videoId;
-    lines.push(`▶ ${title}`, `   https://www.youtube.com/watch?v=${videoId}`, '');
+    lines.push(`▶ ${title}`, `   ${ytWatchUrl(videoId)}`, '');
     bookmarks.sort((a, b) => a.timestamp - b.timestamp).forEach(b => {
       lines.push(`   ${formatTimestamp(b.timestamp)}  ${b.description || 'No note'}`);
       if (b.notes?.trim()) lines.push(`   Note: ${b.notes}`);
@@ -1013,7 +992,7 @@ async function exportReadingList() {
     lines.push('');
   }
 
-  downloadFile(lines.join('\n'), 'clipmark-reading-list.txt', 'text/plain');
+  downloadFile(lines.join('\n'), `${APP_EXPORT_PREFIX}-reading-list.txt`, 'text/plain');
 }
 
 // ─── Import ───────────────────────────────────────────────────────────────────
@@ -1230,8 +1209,8 @@ async function renderGroupsView() {
       const bookmarks = allBookmarks.filter(b => b.videoId === videoId);
       const title     = bookmarks[0]?.videoTitle || videoTitles[videoId] || videoId;
       const count     = bookmarks.length;
-      const thumb     = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
-      const ytUrl     = `https://www.youtube.com/watch?v=${videoId}`;
+      const thumb     = ytThumbnailUrl(videoId);
+      const ytUrl     = ytWatchUrl(videoId);
       return `
         <div class="gv-video-card">
           <a href="${ytUrl}" target="_blank" rel="noopener">
@@ -1349,8 +1328,8 @@ async function renderGroupsView() {
         const bookmarks = allBookmarks.filter(b => b.videoId === videoId);
         const title = bookmarks[0]?.videoTitle || videoTitles[videoId] || videoId;
         const count = bookmarks.length;
-        const thumb = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
-        const ytUrl = `https://www.youtube.com/watch?v=${videoId}`;
+        const thumb = ytThumbnailUrl(videoId);
+        const ytUrl = ytWatchUrl(videoId);
         return `
           <div class="gv-video-card">
             <a href="${ytUrl}" target="_blank" rel="noopener">
@@ -1487,7 +1466,7 @@ async function renderRevisitView(container, highlightTargetId = null) {
       return;
     }
     const bms = allBookmarks.filter(b => b.videoId === targetId);
-    rmPreviewThumb.src = `https://img.youtube.com/vi/${targetId}/mqdefault.jpg`;
+    rmPreviewThumb.src = ytThumbnailUrl(targetId);
     rmPreviewTitle.textContent = bms[0].videoTitle || '';
     const tags = [...new Set(bms.flatMap(b => b.tags || []))].slice(0, 4);
     rmPreviewTags.innerHTML = tags.map(t =>
@@ -1504,7 +1483,7 @@ async function renderRevisitView(container, highlightTargetId = null) {
         .filter(b => b.videoId && b.videoTitle)
         .map(b => [b.videoId, b.videoTitle])
     ).entries()]
-      .map(([vid, title]) => `<option value="${vid}">${title.substring(0, 60)}</option>`)
+      .map(([vid, title]) => `<option value="${vid}">${title.substring(0, TITLE_TRUNCATE_LENGTH)}</option>`)
       .join('');
 
     // Fetch groups for the Collection/Group tab
@@ -1773,7 +1752,7 @@ async function renderRevisitView(container, highlightTargetId = null) {
     const freqMap = { once: 'One-time', daily: 'Daily', weekly: 'Weekly', biweekly: 'Biweekly', monthly: 'Monthly' };
     const freqLabel = freqMap[r.frequency] || r.frequency;
     const thumbHtml = r.videoId
-      ? `<img class="rm-card-thumb" src="https://img.youtube.com/vi/${r.videoId}/mqdefault.jpg" loading="lazy" alt="">`
+      ? `<img class="rm-card-thumb" src="${ytThumbnailUrl(r.videoId)}" loading="lazy" alt="">`
       : '';
 
     const card = document.createElement('div');
@@ -1788,7 +1767,7 @@ async function renderRevisitView(container, highlightTargetId = null) {
         <div class="rm-card-title">${r.label || r.targetLabel || 'Unknown'}</div>
         ${r.label ? `<div class="rm-card-sub">${r.targetLabel}</div>` : ''}
         <div class="rm-card-actions">
-          ${isDue && r.videoId ? `<a class="rm-btn rm-btn-revisit" href="https://www.youtube.com/watch?v=${r.videoId}" target="_blank" rel="noopener">Revisit ↗</a>` : ''}
+          ${isDue && r.videoId ? `<a class="rm-btn rm-btn-revisit" href="${ytWatchUrl(r.videoId)}" target="_blank" rel="noopener">Revisit ↗</a>` : ''}
           ${isDue ? `<button class="rm-btn rm-btn-done">Mark Done</button>` : ''}
           <button class="rm-btn rm-btn-edit">Edit →</button>
           <button class="rm-btn-delete" title="Delete">×</button>
@@ -1893,7 +1872,7 @@ async function renderVideosView(container) {
   videoIds.forEach(videoId => {
     const bookmarks = grouped[videoId];
     const title     = bookmarks[0].videoTitle || videoTitles[videoId] || `Video: ${videoId}`;
-    const thumb     = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
+    const thumb     = ytThumbnailUrl(videoId);
     const count     = bookmarks.length;
     const lastSaved = Math.max(...bookmarks.map(b => b.id));
 
@@ -1985,9 +1964,7 @@ async function renderSharedView(container) {
   grid.className = 'sh-grid';
 
   collections.forEach(col => {
-    const thumb = col.video_id
-      ? `https://img.youtube.com/vi/${col.video_id}/mqdefault.jpg`
-      : '';
+    const thumb = col.video_id ? ytThumbnailUrl(col.video_id) : '';
     const shareUrl = `${API_BASE}/v/${col.id}`;
 
     const card = document.createElement('div');

--- a/extension/src/popup/popup.js
+++ b/extension/src/popup/popup.js
@@ -28,34 +28,7 @@ async function getValidToken() {
   }
 }
 
-// ─── Tag colours ────────────────────────────────────────────────────────────
-const TAG_COLORS = {
-  important: '#ef4444',
-  review:    '#f97316',
-  note:      '#3b82f6',
-  question:  '#22c55e',
-  todo:      '#a855f7',
-  key:       '#ec4899',
-};
-
-function parseTags(description) {
-  if (!description) return [];
-  const matches = description.match(/#(\w+)/g);
-  return matches ? matches.map(t => t.slice(1).toLowerCase()) : [];
-}
-
-function stringToColor(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return `hsl(${Math.abs(hash) % 360}, 55%, 45%)`;
-}
-
-function getTagColor(tags) {
-  if (!tags || tags.length === 0) return '#4da1ee';
-  return TAG_COLORS[tags[0]] || stringToColor(tags[0]);
-}
+// TAG_COLORS, parseTags, stringToColor, getTagColor are defined in constants.js
 
 // ─── Utilities ───────────────────────────────────────────────────────────────
 function extractVideoId(url) {
@@ -92,7 +65,7 @@ function sendMessageToTab(tabId, message) {
   });
 }
 
-async function waitForContentScript(tabId, maxRetries = 3, delay = 1000) {
+async function waitForContentScript(tabId, maxRetries = MAX_RECONNECT_ATTEMPTS, delay = RECONNECT_DELAY) {
   for (let i = 0; i < maxRetries; i++) {
     try {
       const r = await sendMessageToTab(tabId, { action: 'ping' });
@@ -821,7 +794,7 @@ async function loadSpacedRevision() {
       }
       const { videoId } = el.dataset;
       await advanceRevisitReminder(videoId);
-      chrome.tabs.create({ url: `https://www.youtube.com/watch?v=${videoId}` });
+      chrome.tabs.create({ url: ytWatchUrl(videoId) });
       loadSpacedRevision();
     });
   });
@@ -834,7 +807,7 @@ async function loadSpacedRevision() {
       if (tab?.url?.includes(`youtube.com/watch?v=${videoId}`)) {
         await handleBookmarkClick(tab, timestamp);
       } else {
-        chrome.tabs.create({ url: `https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(parseFloat(timestamp))}` });
+        chrome.tabs.create({ url: ytWatchUrl(videoId, parseFloat(timestamp)) });
       }
     });
   });
@@ -935,7 +908,7 @@ async function loadBookmarks() {
       // Copy link
       el.querySelector('.copy-link').addEventListener('click', async e => {
         e.stopPropagation();
-        const url = `https://www.youtube.com/watch?v=${vId}&t=${Math.floor(parseFloat(timestamp))}`;
+        const url = ytWatchUrl(vId, parseFloat(timestamp));
         await navigator.clipboard.writeText(url);
         showStatus('Link copied!');
       });

--- a/extension/src/popup/side-panel.js
+++ b/extension/src/popup/side-panel.js
@@ -33,34 +33,7 @@ async function getValidToken() {
   }
 }
 
-// ─── Tag colours ────────────────────────────────────────────────────────────
-const TAG_COLORS = {
-  important: '#ff6b6b',
-  review:    '#ffa94d',
-  note:      '#74c0fc',
-  question:  '#a9e34b',
-  todo:      '#da77f2',
-  key:       '#f783ac',
-};
-
-function parseTags(description) {
-  if (!description) return [];
-  const matches = description.match(/#(\w+)/g);
-  return matches ? matches.map(t => t.slice(1).toLowerCase()) : [];
-}
-
-function stringToColor(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return `hsl(${Math.abs(hash) % 360}, 60%, 60%)`;
-}
-
-function getTagColor(tags) {
-  if (!tags || tags.length === 0) return '#4da1ee';
-  return TAG_COLORS[tags[0]] || stringToColor(tags[0]);
-}
+// TAG_COLORS, parseTags, stringToColor, getTagColor are defined in constants.js
 
 function formatTimestamp(seconds) {
   const m = Math.floor(seconds / 60);
@@ -188,7 +161,7 @@ function sendMessageToTab(tabId, message) {
   });
 }
 
-async function waitForContentScript(tabId, maxRetries = 3, delay = 1000) {
+async function waitForContentScript(tabId, maxRetries = MAX_RECONNECT_ATTEMPTS, delay = RECONNECT_DELAY) {
   for (let i = 0; i < maxRetries; i++) {
     try {
       const r = await sendMessageToTab(tabId, { action: 'ping' });
@@ -905,7 +878,7 @@ async function loadBookmarks() {
       // Copy link
       el.querySelector('.copy-link').addEventListener('click', async e => {
         e.stopPropagation();
-        const url = `https://www.youtube.com/watch?v=${vId}&t=${Math.floor(parseFloat(timestamp))}`;
+        const url = ytWatchUrl(vId, parseFloat(timestamp));
         await navigator.clipboard.writeText(url);
         showStatus('Link copied!');
       });

--- a/webapp/app/components/Footer.tsx
+++ b/webapp/app/components/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SUPPORT_EMAIL } from '@/app/lib/constants';
 
 export function Footer() {
   return (
@@ -12,7 +13,7 @@ export function Footer() {
           <a href="/upgrade" style={{ color: '#545f6c', fontSize: 14, textDecoration: 'none' }}>Pricing</a>
           <a href="/privacy" style={{ color: '#545f6c', fontSize: 14, textDecoration: 'none' }}>Privacy</a>
           <a href="/terms" style={{ color: '#545f6c', fontSize: 14, textDecoration: 'none' }}>Terms</a>
-          <a href="mailto:support@clipmark.app" style={{ color: '#545f6c', fontSize: 14, textDecoration: 'none' }}>Support</a>
+          <a href={`mailto:${SUPPORT_EMAIL}`} style={{ color: '#545f6c', fontSize: 14, textDecoration: 'none' }}>Support</a>
         </div>
       </div>
     </footer>

--- a/webapp/app/lib/constants.ts
+++ b/webapp/app/lib/constants.ts
@@ -1,0 +1,4 @@
+export const APP_NAME      = 'Clipmark';
+export const SUPPORT_EMAIL = 'support@clipmark.app';
+export const PRIVACY_EMAIL = 'privacy@clipmark.app';
+export const LEGAL_EMAIL   = 'legal@clipmark.app';

--- a/webapp/app/privacy/page.tsx
+++ b/webapp/app/privacy/page.tsx
@@ -1,3 +1,5 @@
+import { PRIVACY_EMAIL } from '@/app/lib/constants';
+
 export const metadata = {
   title: 'Privacy Policy — Clipmark',
   description: 'How Clipmark collects, uses, and protects your data.',
@@ -170,7 +172,7 @@ export default function PrivacyPage() {
           <h2 style={H2_STYLE}>9. Contact</h2>
           <p style={P_STYLE}>
             If you have questions or requests regarding your data, please contact us at:<br />
-            <a href="mailto:privacy@clipmark.app" style={{ color: '#14B8A6', fontWeight: 600 }}>privacy@clipmark.app</a>
+            <a href={`mailto:${PRIVACY_EMAIL}`} style={{ color: '#14B8A6', fontWeight: 600 }}>{PRIVACY_EMAIL}</a>
           </p>
         </div>
 

--- a/webapp/app/terms/page.tsx
+++ b/webapp/app/terms/page.tsx
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL, LEGAL_EMAIL } from '@/app/lib/constants';
+
 export const metadata = {
   title: 'Terms of Service — Clipmark',
   description: 'Terms and conditions for using Clipmark.',
@@ -113,7 +115,7 @@ export default function TermsPage() {
           <ul style={UL_STYLE}>
             <li style={LI_STYLE}><strong>Billing</strong> — subscriptions are billed monthly or annually as selected. Payments are processed by Dodo Payments.</li>
             <li style={LI_STYLE}><strong>Cancellation</strong> — you may cancel at any time. Pro features remain active until the end of the current billing period. No prorated refunds for partial periods on monthly plans.</li>
-            <li style={LI_STYLE}><strong>Refunds</strong> — we offer a 7-day money-back guarantee for new subscribers. Contact <a href="mailto:support@clipmark.app" style={{ color: '#14B8A6' }}>support@clipmark.app</a> within 7 days of your first payment to request a full refund.</li>
+            <li style={LI_STYLE}><strong>Refunds</strong> — we offer a 7-day money-back guarantee for new subscribers. Contact <a href={`mailto:${SUPPORT_EMAIL}`} style={{ color: '#14B8A6' }}>{SUPPORT_EMAIL}</a> within 7 days of your first payment to request a full refund.</li>
             <li style={LI_STYLE}><strong>Lifetime plans</strong> — one-time payment grants lifetime access to Pro features available at time of purchase. Future features may require a subscription upgrade.</li>
             <li style={LI_STYLE}><strong>Price changes</strong> — we may change subscription prices with 30 days&apos; notice. Existing subscribers will be grandfathered at their current rate for one additional billing cycle.</li>
           </ul>
@@ -181,7 +183,7 @@ export default function TermsPage() {
           <h2 style={H2_STYLE}>11. Contact</h2>
           <p style={P_STYLE}>
             Questions about these Terms? Contact us at:<br />
-            <a href="mailto:legal@clipmark.app" style={{ color: '#14B8A6', fontWeight: 600 }}>legal@clipmark.app</a>
+            <a href={`mailto:${LEGAL_EMAIL}`} style={{ color: '#14B8A6', fontWeight: 600 }}>{LEGAL_EMAIL}</a>
           </p>
         </div>
 

--- a/webapp/app/v/[shareId]/page.tsx
+++ b/webapp/app/v/[shareId]/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { supabase, type Collection, type Bookmark } from '@/lib/supabase';
 import styles from './page.module.css';
 import { CopyLinkButton } from './CopyLinkButton';
+import { SUPPORT_EMAIL } from '@/app/lib/constants';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 function formatTimestamp(seconds: number): string {
@@ -383,7 +384,7 @@ export default async function SharePage(
           <ul className={styles.footerLinks}>
             <li><a href="/privacy" className={styles.footerLink}>Privacy</a></li>
             <li><a href="/terms" className={styles.footerLink}>Terms</a></li>
-            <li><a href="mailto:support@clipmark.app" className={styles.footerLink}>Support</a></li>
+            <li><a href={`mailto:${SUPPORT_EMAIL}`} className={styles.footerLink}>Support</a></li>
           </ul>
         </div>
       </footer>


### PR DESCRIPTION
Introduce extension/src/constants.js and webapp/app/lib/constants.ts as single sources of truth for values that were duplicated or scattered. Also fixes a bug where side-panel.js used different TAG_COLORS hex values than all other files, causing inconsistent tag colors depending on which UI rendered the bookmark.

Changes:
- Add extension/src/constants.js with TAG_COLORS, YouTube URL helpers (ytWatchUrl, ytThumbnailUrl), APP_EXPORT_PREFIX, MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY, TITLE_TRUNCATE_LENGTH, TRANSCRIPT_TRUNCATE_LENGTH
- Load constants.js in manifest content_scripts, web_accessible_resources, and all three extension HTML pages before other scripts
- Remove local TAG_COLORS/parseTags/stringToColor/getTagColor from content.js, popup.js, dashboard.js, and side-panel.js (bug fix for side-panel color mismatch)
- Replace 20+ hardcoded YouTube URL string literals with ytWatchUrl/ytThumbnailUrl
- Replace export filenames with APP_EXPORT_PREFIX template literals in dashboard.js
- Use MAX_RECONNECT_ATTEMPTS and RECONNECT_DELAY in waitForContentScript defaults
- Add webapp/app/lib/constants.ts with SUPPORT_EMAIL, PRIVACY_EMAIL, LEGAL_EMAIL
- Update Footer, terms, privacy, and share page to import email constants